### PR TITLE
Add support for latest deemix version

### DIFF
--- a/root/scripts/dlclient.py
+++ b/root/scripts/dlclient.py
@@ -49,9 +49,9 @@ class cli(deemix):
         for link in url:
             if ';' in link:
                 for l in link.split(";"):
-                    self.qm.addToQueue(self.dz, self.sp, l, self.set.settings, bitrate)
+                    self.qm.addToQueue(self.dz, l, self.set.settings, bitrate)
             else:
-                self.qm.addToQueue(self.dz, self.sp, link, self.set.settings, bitrate)
+                self.qm.addToQueue(self.dz, link, self.set.settings, bitrate)
 
     def requestValidArl(self):
         while True:


### PR DESCRIPTION
The arguments of `addToQueue` changed. Related commit in deemix: https://codeberg.org/RemixDev/deemix/commit/d6106f30b78565769a45fe06f2a1e3d5285890e1